### PR TITLE
CODE_OF_CONDUCT.md を railsguides.jp 側の修正を優先するように修正

### DIFF
--- a/import-upstream
+++ b/import-upstream
@@ -15,7 +15,7 @@ head_branch_name=${base_branch_name}-${d}
 
 upstream_branch_name=master
 
-ours_files=(.gitignore .travis.yml Gemfile Gemfile.lock guides/rails_guides.rb guides/assets/javascripts/guides.js guides/assets/stylesheets/main.css)
+ours_files=(.gitignore .travis.yml CODE_OF_CONDUCT.md Gemfile Gemfile.lock guides/rails_guides.rb guides/assets/javascripts/guides.js guides/assets/stylesheets/main.css)
 deleted_files=(CONTRIBUTING.md .github/issue_template.md .github/pull_request_template.md .github/stale.yml)
 
 cd /usr/src/railsguides.jp


### PR DESCRIPTION
`CODE_OF_CONDUCT.md` の問い合わせ先が `rails/rails` 向けになっており、今後 `CODE_OF_CONDUCT.md` を `railsguides.jp` 向けに修正した後、原著の更新を取り込む際に修正が元に戻らないように設定しておく。