### PR TITLE
自動マージスクリプトから git config の設定部分を削除

### DIFF
--- a/import-upstream
+++ b/import-upstream
@@ -4,10 +4,6 @@ set -ex
 
 d=`TZ=UTC date +%Y%m%d%H%M%S`
 
-# set github user config
-git config --global user.name "username"
-git config --global user.email "address"
-
 rails_clone_url=https://github.com/rails/rails.git
 
 base_branch_name=master

--- a/server.rb
+++ b/server.rb
@@ -40,6 +40,8 @@ post "/" do
   begin
     payload = JSON.parse(@payload)
 
+    logger.info(payload)
+
     unless auto_mergeable?(payload)
       halt 200
     end


### PR DESCRIPTION
`git` は以下の環境変数を設定していると自動的に反映してくれるので、その方法を利用するように修正

* GIT_AUTHOR_NAME
* GIT_AUTHOR_EMAIL
* GIT_COMMITTER_NAME
* GIT_COMMITTER_EMAIL

> git configせずに環境変数で設定してあげるほうが便利かもしれません by hanachin

ref: https://git-scm.com/book/en/v2/Git-Internals-Environment-Variables