### PR TITLE
Gemfile関連のファイルを自動コンフリクト解決対象から除外する

### DIFF
--- a/import-upstream
+++ b/import-upstream
@@ -11,7 +11,7 @@ head_branch_name=${base_branch_name}-${d}
 
 upstream_branch_name=master
 
-ours_files=(README.md .gitignore .travis.yml CODE_OF_CONDUCT.md Gemfile Gemfile.lock guides/rails_guides.rb guides/assets/javascripts/guides.js guides/assets/stylesheets/main.css)
+ours_files=(README.md .gitignore .travis.yml CODE_OF_CONDUCT.md guides/rails_guides.rb guides/assets/javascripts/guides.js guides/assets/stylesheets/main.css)
 deleted_files=(CONTRIBUTING.md .github/issue_template.md .github/pull_request_template.md .github/stale.yml)
 
 cd /usr/src/railsguides.jp


### PR DESCRIPTION
`rails/rails` では Gemfile 関連の変更が頻繁に発生しており、`railsguides.jp` に変更を取り込む際にコンフリクトが発生することが多々存在していたので、自動的に `railsguides.jp` のほうの変更を優先するように、`ours_files` というリストに追加していたが、自動的にコンフリクトを解決した結果 CI が失敗した場合に、整合性を取るために過去の変更を追いかける必要があり、コンフリクト解消に対するコストが大きいため、自動コンフリクト解決の対象から外すようにする。

これによって、`Gemfile`, `Gemfile.lock` でコンフリクトが発生した際に自動取り込みは失敗するが。コンフリクトの解消作業のコストは小さくなると思われる。